### PR TITLE
feat(ui): added ability for user to define prompt

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -20,6 +20,7 @@ The table below gives a short overiew of `nubia.PluginInterface`' most important
 | `get_opts_parser` | Provides the top-level argument parser that handles common arguments |
 | `create_context` | Provides a context object |
 | `get_status_bar` | Provides a status bar |
+| `get_prompt_tokens` | Provides prompt tokens for interactive prompt |
 
 ### Context
 A _context_ is an object that extends `nubia.Context` class.

--- a/nubia/internal/context.py
+++ b/nubia/internal/context.py
@@ -25,7 +25,6 @@ class Context(Listener):
         self._testing = None
         self._registry = None
         self._args = {}
-        self._tier = ""
 
     def set_binary_name(self, name):
         self._binary_name = name
@@ -53,10 +52,6 @@ class Context(Listener):
 
         with self._lock:
             self._args.verbose = value
-
-    def set_tier(self, tier: str):
-        with self._lock:
-            self._tier = tier
 
     @property
     def binary_name(self):
@@ -86,10 +81,11 @@ class Context(Listener):
         Override this and return your own prompt for interactive mode.
         Expected to return a list of pygments Token tuples.
         """
-        tokens = [(Token.Username, getpass.getuser())]
-        if self._tier:
-            tokens.extend([(Token.At, "@"), (Token.Tier, self._tier)])
-        tokens.extend([(Token.Colon, ""), (Token.Pound, "> ")])
+        tokens = [
+            (Token.Username, getpass.getuser()),
+            (Token.Colon, ""),
+            (Token.Pound, "> "),
+        ]
         return tokens
 
     def on_connected(self, *args, **kwargs):

--- a/nubia/internal/interactive.py
+++ b/nubia/internal/interactive.py
@@ -28,7 +28,7 @@ from prompt_toolkit.buffer import Buffer
 from termcolor import cprint
 from nubia.internal.ui.lexer import NubiaLexer
 from pygments.token import Token
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 import getpass
 import os
@@ -43,7 +43,6 @@ def split_command(text):
 
 
 class IOLoop(Listener):
-    _tier = ""
     stop_requested = False
 
     def __init__(self, context, plugin, usagelogger):
@@ -113,12 +112,8 @@ class IOLoop(Listener):
         cli = CommandLineInterface(application=application, eventloop=eventloop)
         return cli
 
-    def get_prompt_tokens(self, cli):
-        tokens: List[Tuple] = self._plugin.get_prompt_tokens()
-        if self._tier:
-            tokens.extend([(Token.At, "@"), (Token.Tier, self._tier)])
-        tokens.extend([(Token.Colon, ""), (Token.Pound, "> ")])
-        return tokens
+    def get_prompt_tokens(self, cli) -> List[Tuple[Any, str]]:
+        return self._plugin.get_prompt_tokens(self._ctx)
 
     def parse_and_evaluate(self, stdout, input):
         command_parts = split_command(input)
@@ -188,7 +183,7 @@ class IOLoop(Listener):
     def on_connected(self, *args, **kwargs):
         if args:
             tier = args[0]
-            self._tier = tier
+            self._ctx.set_tier(tier)
 
     @classmethod
     def stop(cls):

--- a/nubia/internal/interactive.py
+++ b/nubia/internal/interactive.py
@@ -27,10 +27,8 @@ from prompt_toolkit.layout.processors import (
 from prompt_toolkit.buffer import Buffer
 from termcolor import cprint
 from nubia.internal.ui.lexer import NubiaLexer
-from pygments.token import Token
 from typing import List, Tuple, Any
 
-import getpass
 import os
 
 from nubia.internal.io.eventbus import Listener
@@ -181,9 +179,7 @@ class IOLoop(Listener):
         self._status_bar.stop()
 
     def on_connected(self, *args, **kwargs):
-        if args:
-            tier = args[0]
-            self._ctx.set_tier(tier)
+        pass
 
     @classmethod
     def stop(cls):

--- a/nubia/internal/interactive.py
+++ b/nubia/internal/interactive.py
@@ -113,7 +113,9 @@ class IOLoop(Listener):
         return cli
 
     def get_prompt_tokens(self, cli):
-        tokens = [(Token.Username, getpass.getuser())]
+        tokens = self._plugin.get_prompt_tokens()
+        if tokens is None:
+            tokens = [(Token.Username, getpass.getuser())]
         if self._tier:
             tokens.extend([(Token.At, "@"), (Token.Tier, self._tier)])
         tokens.extend([(Token.Colon, ""), (Token.Pound, "> ")])

--- a/nubia/internal/interactive.py
+++ b/nubia/internal/interactive.py
@@ -28,6 +28,7 @@ from prompt_toolkit.buffer import Buffer
 from termcolor import cprint
 from nubia.internal.ui.lexer import NubiaLexer
 from pygments.token import Token
+from typing import List, Tuple
 
 import getpass
 import os
@@ -113,9 +114,7 @@ class IOLoop(Listener):
         return cli
 
     def get_prompt_tokens(self, cli):
-        tokens = self._plugin.get_prompt_tokens()
-        if tokens is None:
-            tokens = [(Token.Username, getpass.getuser())]
+        tokens: List[Tuple] = self._plugin.get_prompt_tokens()
         if self._tier:
             tokens.extend([(Token.At, "@"), (Token.Tier, self._tier)])
         tokens.extend([(Token.Colon, ""), (Token.Pound, "> ")])

--- a/nubia/internal/plugin_interface.py
+++ b/nubia/internal/plugin_interface.py
@@ -8,6 +8,10 @@
 #
 
 import argparse
+import getpass
+
+from typing import List, Tuple
+from pygments.token import Token
 from nubia.internal.constants import DEFAULT_COMMAND_TIMEOUT
 from nubia.internal.ui import statusbar
 from nubia.internal.context import Context
@@ -137,9 +141,9 @@ class PluginInterface(object):
         """
         return CommandBlacklist()
 
-    def get_prompt_tokens(self):
+    def get_prompt_tokens(self) -> List[Tuple]:
         """
         Override this and return your own prompt for interactive mode.
         Expected to return a list of pygments Token tuples
         """
-        return None
+        return [(Token.Username, getpass.getuser())]

--- a/nubia/internal/plugin_interface.py
+++ b/nubia/internal/plugin_interface.py
@@ -136,3 +136,10 @@ class PluginInterface(object):
         Any return other then 0 will block command execution
         """
         return CommandBlacklist()
+
+    def get_prompt_tokens(self):
+        """
+        Override this and return your own prompt for interactive mode.
+        Expected to return a list of pygments Token tuples
+        """
+        return None

--- a/nubia/internal/plugin_interface.py
+++ b/nubia/internal/plugin_interface.py
@@ -10,7 +10,7 @@
 import argparse
 import getpass
 
-from typing import List, Tuple
+from typing import List, Tuple, Any
 from pygments.token import Token
 from nubia.internal.constants import DEFAULT_COMMAND_TIMEOUT
 from nubia.internal.ui import statusbar
@@ -119,6 +119,9 @@ class PluginInterface(object):
     def get_status_bar(self, context):
         return statusbar.StatusBar(context)
 
+    def get_prompt_tokens(self, context) -> List[Tuple[Any, str]]:
+        return context.get_prompt_tokens()
+
     def setup_logging(self, root_logger, args):
         """
         Override this and configure your own logging setup. Return your root
@@ -140,10 +143,3 @@ class PluginInterface(object):
         Any return other then 0 will block command execution
         """
         return CommandBlacklist()
-
-    def get_prompt_tokens(self) -> List[Tuple]:
-        """
-        Override this and return your own prompt for interactive mode.
-        Expected to return a list of pygments Token tuples
-        """
-        return [(Token.Username, getpass.getuser())]

--- a/nubia/internal/plugin_interface.py
+++ b/nubia/internal/plugin_interface.py
@@ -8,10 +8,8 @@
 #
 
 import argparse
-import getpass
 
 from typing import List, Tuple, Any
-from pygments.token import Token
 from nubia.internal.constants import DEFAULT_COMMAND_TIMEOUT
 from nubia.internal.ui import statusbar
 from nubia.internal.context import Context
@@ -119,7 +117,7 @@ class PluginInterface(object):
     def get_status_bar(self, context):
         return statusbar.StatusBar(context)
 
-    def get_prompt_tokens(self, context) -> List[Tuple[Any, str]]:
+    def get_prompt_tokens(self, context: Context) -> List[Tuple[Any, str]]:
         return context.get_prompt_tokens()
 
     def setup_logging(self, root_logger, args):


### PR DESCRIPTION
resolves: #4

Added `get_prompt_tokens` function to `PluginInterface`.
interactive.IOLoop now gives precedence to prompt tokens read
from the plugin. Otherwise, the prompt is generated the same
way as before.