### PR TITLE
Don't use pipenv for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ python:
     - "3.6"
 
 install:
-  - pip3 install pipenv
-  - pipenv install -d --system --three
-
+  - pip3 install pipenv nose
+  - python3 setup.py install
 
 script:
   - nosetests
@@ -14,4 +13,5 @@ notifications:
   email:
     recipients:
       - asoli@fb.com
+      - cmarchent@fb.com
     on_failure: change # default: always


### PR DESCRIPTION
Using language "python" in Travis starts up within a virtualenv; current
version of pipenv does not like to be run within an existing virtualenv;
we do require the pipenv library, to get dependencies, as we require
nose for the unit tests; so these are installed manually for the travis
job.