### PR TITLE
Try pinning back pyparsing to 2.2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 termcolor = "*"
 python-Levenshtein = "*"
-pyparsing = "*"
+pyparsing = "<=2.2"
 prettytable = "*"
 prompt-toolkit = "<=2"
 pygments = "*"


### PR DESCRIPTION
Not a complete solution, but will allow tests to run while we integrate
with 2.3.1.