### PR TITLE
Unwrap the use of dictOf

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 termcolor = "*"
 python-Levenshtein = "*"
-pyparsing = "<=2.2"
+pyparsing = "*"
 prettytable = "*"
 prompt-toolkit = "<=2"
 pygments = "*"

--- a/nubia/internal/parser.py
+++ b/nubia/internal/parser.py
@@ -95,7 +95,7 @@ positionals = pp.ZeroOrMore(
     value + (pp.StringEnd() ^ pp.Suppress(pp.OneOrMore(pp.White())))
 ).setResultsName("positionals")
 
-key_value = pp.dictOf(identifier + pp.Suppress("="), value).setResultsName("kv")
+key_value = pp.Dict( pp.ZeroOrMore( pp.Group( identifier + pp.Suppress("=") + value ) ) ).setResultsName("kv")
 
 subcommand = identifier.setResultsName("__subcommand__")
 


### PR DESCRIPTION
In pyparsing 2.3.1 the implementation changed to become

```
Dict(OneOrMore(Group(key + value)))
```
see: https://github.com/pyparsing/pyparsing/issues/53

causing the unit tests to fail. Use the original implementation
directly.

We no longer need to "pin-back" the version of pyparsing