### PR TITLE
Support for prompt-toolkit>=2

### DIFF
--- a/example/nubia_statusbar.py
+++ b/example/nubia_statusbar.py
@@ -17,7 +17,7 @@ class NubiaExampleStatusBar(statusbar.StatusBar):
     def __init__(self, context):
         self._last_status = None
 
-    def get_rprompt_tokens(self, cli):
+    def get_rprompt_tokens(self):
         if self._last_status:
             return [(Token.RPrompt, "Error: {}".format(self._last_status))]
         return []
@@ -25,7 +25,7 @@ class NubiaExampleStatusBar(statusbar.StatusBar):
     def set_last_command_status(self, status):
         self._last_status = status
 
-    def get_tokens(self, cli):
+    def get_tokens(self):
         spacer = (Token.Spacer, "  ")
         if context.get_context().verbose:
             is_verbose = (Token.Warn, "ON")

--- a/nubia/internal/cmdbase.py
+++ b/nubia/internal/cmdbase.py
@@ -16,8 +16,7 @@ import typing
 from typing import Iterable
 from collections import OrderedDict
 
-from prompt_toolkit.completion import Completion
-from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit.completion import Completion, WordCompleter
 from prompt_toolkit.document import Document
 from prompt_toolkit.completion import CompleteEvent
 from termcolor import cprint
@@ -88,9 +87,7 @@ class Command(object):
         """
         return {}
 
-    def get_completions(
-        self, cmd, document, complete_event
-    ) -> Iterable[Completion]:
+    def get_completions(self, cmd, document, complete_event) -> Iterable[Completion]:
         """
         This function SHOULD be implemented to feed the interactive auto
         completion of command arguments. Example: auto complete the available
@@ -155,8 +152,7 @@ class AutoCommand(Command):
                 "Expecting either a function (eg. bar) or "
                 "a bound method (eg. Foo().bar). "
                 "You passed what appears to be an unbound method "
-                "(eg. Foo.bar) it has a 'self' argument: %s"
-                % function_to_str(fn)
+                "(eg. Foo.bar) it has a 'self' argument: %s" % function_to_str(fn)
             )
 
         if not self.metadata.command:
@@ -193,14 +189,10 @@ class AutoCommand(Command):
         """
         kwargs = {
             k: v
-            for k, v in get_arguments_for_inspection(
-                self.metadata, key_values
-            ).items()
+            for k, v in get_arguments_for_inspection(self.metadata, key_values).items()
             if v is not None
         }
-        remaining = {
-            k: v for k, v in key_values.items() if k not in kwargs.keys()
-        }
+        remaining = {k: v for k, v in key_values.items() if k not in kwargs.keys()}
         return self._fn(**kwargs), remaining
 
     def run_interactive(self, cmd, args, raw):
@@ -228,15 +220,11 @@ class AutoCommand(Command):
                 if not sub_inspection:
                     cprint(
                         "Invalid sub-command '{}', valid values: "
-                        "{}".format(
-                            subcommand, ", ".join(self._get_subcommands())
-                        ),
+                        "{}".format(subcommand, ", ".join(self._get_subcommands())),
                         "red",
                     )
                     return 2
-                instance, remaining_args = self._create_subcommand_obj(
-                    args_dict
-                )
+                instance, remaining_args = self._create_subcommand_obj(args_dict)
                 assert instance
                 args_dict = remaining_args
                 key_values = copy.copy(args_dict)
@@ -248,9 +236,7 @@ class AutoCommand(Command):
             else:
                 # not a super-command, use use the function instead
                 fn = self._fn
-            positionals = (
-                parsed_dict["positionals"] if parsed.positionals != "" else []
-            )
+            positionals = parsed_dict["positionals"] if parsed.positionals != "" else []
             # We only allow positionals for arguments that have positional=True
             # ِ We filter out the OrderedDict this way to ensure we don't lose the
             # order of the arguments. We also filter out arguments that have
@@ -273,7 +259,7 @@ class AutoCommand(Command):
                         len(can_be_positional),
                         ", ".join(can_be_positional.keys()),
                         len(positionals),
-                        ", ".join(str(x) for x in positionals)
+                        ", ".join(str(x) for x in positionals),
                     )
                 cprint(err, "red")
                 return 2
@@ -311,8 +297,7 @@ class AutoCommand(Command):
             extra_keys = set(args_dict.keys()) - set(args_metadata)
             if extra_keys:
                 cprint(
-                    "Unknown argument(s) {} were"
-                    " passed".format(list(extra_keys)),
+                    "Unknown argument(s) {} were" " passed".format(list(extra_keys)),
                     "magenta",
                 )
                 return 2
@@ -381,9 +366,7 @@ class AutoCommand(Command):
             # arguments appear to be fine, time to run the function
             try:
                 # convert argument names back to match the function signature
-                args_dict = {
-                    args_metadata[k].arg: v for k, v in args_dict.items()
-                }
+                args_dict = {args_metadata[k].arg: v for k, v in args_dict.items()}
                 if inspect.iscoroutinefunction(fn):
                     loop = asyncio.get_event_loop()
                     ret = loop.run_until_complete(fn(**args_dict))
@@ -431,10 +414,7 @@ class AutoCommand(Command):
 
     def _get_subcommands(self) -> Iterable[str]:
         assert self.super_command
-        return [
-            inspection.command.name
-            for _, inspection in self.metadata.subcommands
-        ]
+        return [inspection.command.name for _, inspection in self.metadata.subcommands]
 
     def _kwargs_for_fn(self, fn, args):
         return {

--- a/nubia/internal/interactive.py
+++ b/nubia/internal/interactive.py
@@ -7,33 +7,27 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+from typing import List, Tuple, Any
 import logging
+import os
 
+from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import Completer
 from prompt_toolkit.document import Document
+from prompt_toolkit.enums import EditingMode
+from prompt_toolkit.formatted_text import PygmentsTokens
 from prompt_toolkit.history import FileHistory, InMemoryHistory
-from prompt_toolkit.key_binding.manager import KeyBindingManager
-from prompt_toolkit import CommandLineInterface, Application, AbortAction
-from prompt_toolkit.shortcuts import create_prompt_layout, create_eventloop
-from prompt_toolkit.layout.lexers import PygmentsLexer
-from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
-from prompt_toolkit.filters import Always, HasFocus, IsDone
-from prompt_toolkit.buffer import AcceptAction
-from prompt_toolkit.layout.processors import (
-    ConditionalProcessor,
-    HighlightMatchingBracketProcessor,
-)
-from prompt_toolkit.buffer import Buffer
-from termcolor import cprint
+from prompt_toolkit.layout.processors import HighlightMatchingBracketProcessor
+from prompt_toolkit.lexers import PygmentsLexer
+from prompt_toolkit.patch_stdout import patch_stdout
+
 from nubia.internal.ui.lexer import NubiaLexer
-from typing import List, Tuple, Any
+from termcolor import cprint
 
-import os
-
-from nubia.internal.options import Options
-from nubia.internal.io.eventbus import Listener
 from nubia.internal.helpers import catchall
+from nubia.internal.io.eventbus import Listener
+from nubia.internal.options import Options
 from nubia.internal.ui.style import shell_style
 
 
@@ -42,32 +36,18 @@ def split_command(text):
 
 
 class IOLoop(Listener):
-    stop_requested = False
-
     def __init__(self, context, plugin, usagelogger, options: Options):
         self._ctx = context
         self._command_registry = self._ctx.registry
         self._plugin = plugin
         self._options = options
         self._blacklist = self._plugin.getBlacklistPlugin()
-
         self._status_bar = self._plugin.get_status_bar(context)
-        self._manager = KeyBindingManager(
-            enable_abort_and_exit_bindings=True,
-            enable_system_bindings=True,
-            enable_search=True,
-            enable_auto_suggest_bindings=True,
-        )
-        self._registry = self._manager.registry
-        self._cli = None
-        self._suggestor = AutoSuggestFromHistory()
         self._completer = ShellCompleter(self._command_registry)
         self._command_registry.register_listener(self)
         self._usagelogger = usagelogger
 
     def _build_cli(self):
-        eventloop = create_eventloop()
-
         if self._options.persistent_history:
             history = FileHistory(
                 os.path.join(
@@ -77,30 +57,6 @@ class IOLoop(Listener):
         else:
             history = InMemoryHistory()
 
-        layout = create_prompt_layout(
-            lexer=PygmentsLexer(NubiaLexer),
-            reserve_space_for_menu=5,
-            get_prompt_tokens=self.get_prompt_tokens,
-            get_rprompt_tokens=self._status_bar.get_rprompt_tokens,
-            get_bottom_toolbar_tokens=self._status_bar.get_tokens,
-            display_completions_in_columns=False,
-            multiline=True,
-            extra_input_processors=[
-                ConditionalProcessor(
-                    processor=HighlightMatchingBracketProcessor(chars="[](){}"),
-                    filter=HasFocus(DEFAULT_BUFFER) & ~IsDone(),
-                )
-            ],
-        )
-
-        buf = Buffer(
-            completer=self._completer,
-            history=history,
-            auto_suggest=self._suggestor,
-            complete_while_typing=Always(),
-            accept_action=AcceptAction.RETURN_DOCUMENT,
-        )
-
         # If EDITOR does not exist, take EMACS
         # if it does, try fit the EMACS/VI pattern using upper
         editor = getattr(
@@ -109,33 +65,35 @@ class IOLoop(Listener):
             EditingMode.EMACS,
         )
 
-        application = Application(
+        return PromptSession(
+            history=history,
+            auto_suggest=AutoSuggestFromHistory(),
+            lexer=PygmentsLexer(NubiaLexer),
+            completer=self._completer,
+            input_processors=[HighlightMatchingBracketProcessor(chars="[](){}")],
             style=shell_style,
-            buffer=buf,
+            bottom_toolbar=self._get_bottom_toolbar,
             editing_mode=editor,
-            key_bindings_registry=self._registry,
-            layout=layout,
-            on_exit=AbortAction.RAISE_EXCEPTION,
-            on_abort=AbortAction.RETRY,
-            ignore_case=True,
+            complete_in_thread=True,
+            include_default_pygments_style=False,
         )
 
-        cli = CommandLineInterface(application=application, eventloop=eventloop)
-        return cli
-
-    def get_prompt_tokens(self, cli) -> List[Tuple[Any, str]]:
+    def _get_prompt_tokens(self) -> List[Tuple[Any, str]]:
         return self._plugin.get_prompt_tokens(self._ctx)
+
+    def _get_bottom_toolbar(self) -> List[Tuple[Any, str]]:
+        return PygmentsTokens(self._status_bar.get_tokens())
 
     def parse_and_evaluate(self, stdout, input):
         command_parts = split_command(input)
         if command_parts and command_parts[0]:
             cmd = command_parts[0]
             args = command_parts[1] if len(command_parts) > 1 else None
-            return self.evaluate_command(stdout, cmd, args, input)
+            return self.evaluate_command(cmd, args, input)
 
-    def evaluate_command(self, stdout, cmd, args, raw):
+    def evaluate_command(self, cmd, args, raw):
         if cmd not in self._command_registry:
-            print(file=stdout)
+            print()
             cprint(
                 "Unknown Command '{}',{} type :help to see all "
                 "available commands".format(
@@ -143,7 +101,6 @@ class IOLoop(Listener):
                 ),
                 "magenta",
                 attrs=["bold"],
-                file=stdout,
             )
         else:
             if args is None:
@@ -168,35 +125,33 @@ class IOLoop(Listener):
                 self._status_bar.set_last_command_status(result)
                 return result
             except NotImplementedError as e:
-                cprint(
-                    "[NOT IMPLEMENTED]: {}".format(str(e)),
-                    "yellow",
-                    attrs=["bold"],
-                    file=stdout,
-                )
+                cprint("[NOT IMPLEMENTED]: {}".format(str(e)), "yellow", attrs=["bold"])
                 # not implemented error code
                 return 99
 
     def run(self):
-        self._cli = self._build_cli()
-        stdout = self._cli.stdout_proxy(True)
-        self._status_bar.start(self._cli)
-        try:
-            while not self.stop_requested:
-                document = self._cli.run()
-                text = document.text
-                self.parse_and_evaluate(stdout, text)
-        except (EOFError, KeyboardInterrupt):
-            IOLoop.stop()
-
+        prompt = self._build_cli()
+        with patch_stdout() as stdout:
+            self._status_bar.start()
+            try:
+                while True:
+                    try:
+                        text = prompt.prompt(
+                            PygmentsTokens(self._get_prompt_tokens()),
+                            rprompt=PygmentsTokens(
+                                self._status_bar.get_rprompt_tokens()
+                            ),
+                        )
+                        self.parse_and_evaluate(stdout, text)
+                    except KeyboardInterrupt:
+                        pass
+            except EOFError:
+                # Application exiting.
+                pass
         self._status_bar.stop()
 
     def on_connected(self, *args, **kwargs):
         pass
-
-    @classmethod
-    def stop(cls):
-        cls.stop_requested = True
 
 
 class ShellCompleter(Completer):

--- a/nubia/internal/registry.py
+++ b/nubia/internal/registry.py
@@ -12,7 +12,7 @@ import Levenshtein
 from nubia.internal.cmdbase import Command
 from nubia.internal.io.eventbus import Listener
 
-from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit.completion import WordCompleter
 
 from termcolor import cprint
 

--- a/nubia/internal/ui/statusbar.py
+++ b/nubia/internal/ui/statusbar.py
@@ -21,16 +21,16 @@ class StatusBar(eventbus.Listener):
         """
         pass
 
-    def get_rprompt_tokens(self, cli):
+    def get_rprompt_tokens(self):
         return []
 
     def set_last_command_status(self, status):
         pass
 
-    def get_tokens(self, cli):
+    def get_tokens(self):
         return []
 
-    def start(self, cli):
+    def start(self):
         pass
 
     def stop(self):

--- a/nubia/internal/ui/style.py
+++ b/nubia/internal/ui/style.py
@@ -7,49 +7,60 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-from prompt_toolkit.styles import style_from_pygments
+from prompt_toolkit.styles import (
+    merge_styles,
+    style_from_pygments_cls,
+    style_from_pygments_dict,
+)
+from prompt_toolkit.styles import Style
 from pygments.styles.monokai import MonokaiStyle
 from pygments.token import Token, Name
 
-shell_style = style_from_pygments(
-    MonokaiStyle,
-    {
-        # Commands
-        Name.Command: "#f2b44f",
-        Name.SubCommand: "#f2c46f",
-        Name.InvalidCommand: "bg:#ff0066 #000000",
-        Name.Select: "#0000ff",
-        Name.Query: "#d78700",
-        Name.Key: "#ffffff",
-        Name.Path: "#fff484",
-        Name.Help: "#00aa00",
-        Name.Exit: "#ff0066",
-        # User input.
-        Token: "#ff0066",
-        # Prompt.
-        Token.Username: "#884444",
-        Token.At: "#00aa00",
-        Token.Colon: "#00aa00",
-        Token.Pound: "#00aa00",
-        Token.Tier: "#ff0088",
-        Token.Path: "#884444 underline",
-        Token.RPrompt: "bg:#ff0066 #ffffff",
-        # Toolbar Tokens
-        Token.Toolbar: "#ffffff bg:#1c1c1c",
-        Token.TestTier: "#ff0000 bg:#1c1c1c",
-        Token.ProductionTier: "#ff0000 bg:#1c1c1c",
-        Token.OfflineNodes: "#ff0000 bg:#1c1c1c",
-        Token.NodesCount: "#ffffff bg:#1c1c1c",
-        Token.Spacer: "#ffffff bg:#1c1c1c",
-        # Alarms
-        Token.MinorAlarm: "#0000ff bg:#1c1c1c",
-        Token.MajorAlarm: "#d78700 bg:#1c1c1c",
-        Token.CriticalAlarm: "#ff0000 bg:#1c1c1c",
-        Token.AppendFailures: "#0000ff bg:#1c1c1c",
-        # General
-        Token.Good: "#ffffff bg:#10c010",
-        Token.Bad: "#ffffff bg:#c01010",
-        Token.Info: "#ffffff bg:#1010c0",
-        Token.Warn: "#000000 bg:#c0c010",
-    },
+
+shell_style = merge_styles(
+    [
+        style_from_pygments_cls(MonokaiStyle),
+        style_from_pygments_dict(
+            {
+                # Commands
+                Name.Command: "#f2b44f",
+                Name.SubCommand: "#f2c46f",
+                Name.InvalidCommand: "bg:#ff0066 #000000",
+                Name.Select: "#0000ff",
+                Name.Query: "#d78700",
+                Name.Key: "#ffffff",
+                Name.Path: "#fff484",
+                Name.Help: "#00aa00",
+                Name.Exit: "#ff0066",
+                # User input.
+                Token: "#ff0066",
+                # Prompt.
+                Token.Username: "#884444",
+                Token.At: "#00aa00",
+                Token.Colon: "#00aa00",
+                Token.Pound: "#00aa00",
+                Token.Tier: "#ff0088",
+                Token.Path: "#884444 underline",
+                Token.RPrompt: "bg:#ff0066 #ffffff",
+                # Toolbar Tokens
+                Token.Toolbar: "#ffffff bg:#1c1c1c",
+                Token.TestTier: "#ff0000 bg:#1c1c1c",
+                Token.ProductionTier: "#ff0000 bg:#1c1c1c",
+                Token.OfflineNodes: "#ff0000 bg:#1c1c1c",
+                Token.NodesCount: "#ffffff bg:#1c1c1c",
+                Token.Spacer: "#ffffff bg:#1c1c1c",
+                # Alarms
+                Token.MinorAlarm: "#0000ff bg:#1c1c1c",
+                Token.MajorAlarm: "#d78700 bg:#1c1c1c",
+                Token.CriticalAlarm: "#ff0000 bg:#1c1c1c",
+                Token.AppendFailures: "#0000ff bg:#1c1c1c",
+                # General
+                Token.Good: "#ffffff bg:#10c010",
+                Token.Bad: "#ffffff bg:#c01010",
+                Token.Info: "#ffffff bg:#1010c0",
+                Token.Warn: "#000000 bg:#c0c010",
+            }
+        ),
+        Style.from_dict({"bottom-toolbar": "fg:#ffffff bg:#1c1c1c noinherit"}),
+    ]
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dataclasses
 prettytable
-prompt-toolkit<=2
+prompt-toolkit>=2
 Pygments
 pyparsing>=2.2.0
 python-Levenshtein


### PR DESCRIPTION
A background breaking change to support prompt-toolkit 2+. The changes to our public interfaces are minimal. In StatusBar object we don't pass the (cli) argument anymore.

Note that prompt-toolkit 2 is not compatible with its older versions. This PR introduces the changes necessary to _start_ this support.

Future work will be added to leverage the new features of prompt-toolkit, for this this is done so we can preserve all the behaviour of nubia to be the same.
