### PR TITLE
Include requirements.txt in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include requirements.txt
+include LICENSE
+include *.md

--- a/nubia/__init__.py
+++ b/nubia/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "statusbar",
 ]
 
-__version__ = "0.1b5"
+__version__ = "0.1b6"


### PR DESCRIPTION
setup.py didn't include the requirements.txt causing 0.1b5 package to be faulty. 