### PR TITLE
Do not use `six' module as Nubia is Python 3 only

### DIFF
--- a/nubia/internal/typing/__init__.py
+++ b/nubia/internal/typing/__init__.py
@@ -63,7 +63,6 @@ import inspect
 
 from collections import namedtuple, Container, OrderedDict
 from functools import partial
-from six import string_types
 
 from nubia.internal.helpers import (
     get_arg_spec,
@@ -348,11 +347,11 @@ def _normalize_exclusive_arguments(exclusive_arguments):
     """
 
     def all_string_items(items):
-        return all(isinstance(item, string_types) for item in items)
+        return all(isinstance(item, str) for item in items)
 
     def all_container_items(items):
         return all(
-            isinstance(item, Container) and not isinstance(item, string_types)
+            isinstance(item, Container) and not isinstance(item, str)
             for item in items
         )
 

--- a/nubia/internal/typing/argparse.py
+++ b/nubia/internal/typing/argparse.py
@@ -9,8 +9,8 @@
 
 import argparse
 import os
+import shutil
 import subprocess
-import six
 import copy
 import sys
 
@@ -332,19 +332,12 @@ class NubiaHelpAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         help_message = parser.format_help()
-        if six.PY2:  # deprecated
-            fits_one_page = False
-        else:  # assume Python 3
-            import shutil
-
-            help_message_length = len(help_message.split("\n"))
-            _, rows = shutil.get_terminal_size()
-            fits_one_page = help_message_length <= rows
-        pager = os.environ.get("PAGER", "less")
+        help_message_length = len(help_message.split("\n"))
+        _, rows = shutil.get_terminal_size()
+        fits_one_page = help_message_length <= rows
         if sys.stdout.isatty() and not fits_one_page:
-            p = subprocess.Popen([pager], stdin=subprocess.PIPE)
-            p.communicate(input=six.b(help_message))
-            p.wait()
+            pager = os.environ.get("PAGER", "less")
+            subprocess.run([pager], input=help_message.encode())
         else:  # fallback
             parser.print_help()
         parser.exit()

--- a/nubia/internal/typing/builder.py
+++ b/nubia/internal/typing/builder.py
@@ -14,7 +14,6 @@ import sys
 import typing
 
 from functools import wraps
-from six import string_types, reraise
 
 from nubia.internal.helpers import issubclass_, is_union
 
@@ -86,7 +85,7 @@ def get_typing_function(type):
         func = get_typing_function(subtypes[0])
     elif type == typing.Any:
         func = _identity_function
-    elif issubclass_(type, string_types):
+    elif issubclass_(type, str):
         func = str
     elif issubclass_(type, collections.Mapping):
         func = _apply_dict_type
@@ -118,18 +117,17 @@ def get_typing_function(type):
 def _safe_eval(string):
     try:
         return ast.literal_eval(string)
-    except ValueError:
+    except ValueError as e:
         _, e, tb = sys.exc_info()
         if str(e) == "malformed string":
-            # raise a more meaningful, nicer error
-            msg = '"{}" uses unsafe token/symbols'.format(string)
-            reraise(ValueError, ValueError(msg), tb)
+            # Raise a more meaningful, nicer error
+            raise ValueError(f"`{string}' uses unsafe token/symbols") from e
         else:
             raise
 
 
 def _build_simple_value(string, type):
-    if not type or issubclass_(type, string_types):
+    if not type or issubclass_(type, str):
         return string
     elif issubclass_(type, collections.Mapping):
         entries = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ prompt-toolkit<=2
 Pygments
 pyparsing>=2.2.0
 python-Levenshtein
-six>=1.9
 termcolor
 wcwidth

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -10,14 +10,12 @@
 import argparse
 import inspect
 import typing
-import six
 import unittest
+from io import StringIO
 
 from nubia.internal.typing import command, argument
 from nubia.internal.typing.argparse import add_command, find_command
 from nubia.internal.typing.builder import build_value
-
-from six import StringIO
 
 
 class ParseError(Exception):
@@ -664,7 +662,7 @@ class ArgparseExtensionTest(unittest.TestCase):
             add_command(parser, foo)
 
     def _test(self, command_function, arguments, expected_result):
-        if isinstance(arguments, six.string_types):
+        if isinstance(arguments, str):
             arguments = arguments.split()
 
         parser = ContainedParser()


### PR DESCRIPTION
As per title. Let's start cleaning up Python 2 leftovers.  See #34.