### PR TITLE
Make typing introspection compatible with Python 3.7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+dist: xenial
 language: python
 python:
     - "3.6"
+    - "3.7"
 
 install:
     - pip install codecov

--- a/nubia/internal/helpers.py
+++ b/nubia/internal/helpers.py
@@ -14,7 +14,6 @@ import string
 import subprocess
 
 from collections import namedtuple
-from typing import _Union, Any, Iterable  # noqa T484
 
 
 def add_command_arguments(parser, options):
@@ -163,41 +162,6 @@ def issubclass_(obj, class_):
         return issubclass(obj, class_)
     except (AttributeError, TypeError):
         return False
-
-
-def is_union(t: Any) -> bool:
-    """Check whether type is a Union.
-
-    @param t: type to check
-    @type: Any
-    @returns: `True` if type is a Union, `False` otherwise
-    @rtype: bool
-
-    @note: This is a hack. See https://bugs.python.org/issue29262 and
-    https://github.com/ilevkivskyi/typing_inspect for the rationale behind the
-    implementation.
-    """
-    return type(t) is _Union
-
-
-def is_optional(t: Any) -> bool:
-    """Check whether a type is an Optional.
-
-    @note: This is a hack.
-    """
-    if not is_union(t):
-        return False
-    elif len(t.__args__) > 2:  # `Optional` is a `Union` of 2 values
-        return False
-    else:
-        _, right = t.__args__
-        return right is type(None)  # noqa E721
-
-
-def get_first_type_variable(t: Any) -> Any:
-    """Given an List[T], return T."""
-    assert hasattr(t, "__args__") and len(t.__args__) > 0
-    return t.__args__[0]
 
 
 def catchall(func, *args):

--- a/nubia/internal/typing/builder.py
+++ b/nubia/internal/typing/builder.py
@@ -8,57 +8,64 @@
 #
 
 import ast
-import collections
 import re
 import sys
 import typing
 
 from functools import wraps
 
-from nubia.internal.helpers import issubclass_, is_union
+from nubia.internal.helpers import issubclass_
+from nubia.internal.typing.inspect import (
+    PEP_560,
+    is_iterable_type,
+    is_mapping_type,
+    is_optional_type,
+    is_tuple_type,
+    is_typevar,
+)
 
 
-def build_value(string, type=None, python_syntax=False):
+def build_value(string, tp=None, python_syntax=False):
     value = (
         _safe_eval(string)
         if python_syntax
-        else _build_simple_value(string, type)
+        else _build_simple_value(string, tp)
     )
-    if type:
-        value = apply_typing(value, type)
+    if tp:
+        value = apply_typing(value, tp)
     return value
 
 
-def apply_typing(value, type):
-    return get_typing_function(type)(value)
+def apply_typing(value, tp):
+    return get_typing_function(tp)(value)
 
 
-def get_list_arg_type_as_str(type):
+def get_list_arg_type_as_str(tp):
     """
     This takes a type (typing.List[int]) and returns a string representation of
     the type argument, or "any" if it's not defined
     """
-    assert issubclass_(type, collections.Iterable)
-    args = getattr(type, "__args__", None)
+    assert is_iterable_type(tp)
+    args = getattr(tp, "__args__", None)
     return args[0].__name__ if args else "any"
 
 
-def is_dict_value_iterable(type):
-    assert issubclass_(type, collections.Mapping)
-    args = getattr(type, "__args__", None)
+def is_dict_value_iterable(tp):
+    assert is_mapping_type(tp), f"{tp} is not a mapping type"
+    args = getattr(tp, "__args__", None)
     if args and len(args) == 2:
-        return issubclass_(args[1], typing.List)
+        return is_iterable_type(args[1])
     return False
 
 
-def get_dict_kv_arg_type_as_str(type):
+def get_dict_kv_arg_type_as_str(tp):
     """
     This takes a type (typing.Mapping[str, int]) and returns a tuple (key_type,
     value_type) that contains string representations of the type arguments, or
     "any" if it's not defined
     """
-    assert issubclass_(type, collections.Mapping)
-    args = getattr(type, "__args__", None)
+    assert is_mapping_type(tp), f"{tp} is not a mapping type"
+    args = getattr(tp, "__args__", None)
     key_type = "any"
     value_type = "any"
     if args and len(args) >= 2:
@@ -67,42 +74,48 @@ def get_dict_kv_arg_type_as_str(type):
     return key_type, value_type
 
 
-def get_typing_function(type):
+def get_typing_function(tp):
     func = None
 
     # TypeVars are a problem as they can defined multiple possible types.
     # While a single type TypeVar is somewhat useless, no reason to deny it
     # though
-    if type == typing.TypeVar:
-        subtypes = type.__constraints__
-        if len(subtypes) != 1:
+    if is_typevar(tp):
+        if len(tp.__constraints__) == 0:
+            # Unconstrained TypeVars may come from generics
+            func = _identity_function
+        elif len(tp.__constraints__) == 1:
+            assert not PEP_560, "Python 3.7+ forbids single constraint for `TypeVar'"
+            func = get_typing_function(tp.__constraints__[0])
+        else:
             raise ValueError(
-                "Cannot resolve typing function for TypeVar({}) "
-                "as it declares none or multiple types".format(
-                    ", ".format(str(x) for x in subtypes)
+                "Cannot resolve typing function for TypeVar({constraints}) "
+                "as it declares multiple types".format(
+                    constraints=', '.join(
+                        getattr(c, "_name", c.__name__) for c in tp.__constraints__
+                    )
                 )
             )
-        func = get_typing_function(subtypes[0])
-    elif type == typing.Any:
+    elif tp == typing.Any:
         func = _identity_function
-    elif issubclass_(type, str):
+    elif issubclass_(tp, str):
         func = str
-    elif issubclass_(type, collections.Mapping):
+    elif is_mapping_type(tp):
         func = _apply_dict_type
-    elif issubclass_(type, tuple):
+    elif is_tuple_type(tp):
         func = _apply_tuple_type
-    elif issubclass_(type, collections.Iterable):
+    elif is_iterable_type(tp):
         func = _apply_list_type
-    elif is_union(type):
+    elif is_optional_type(tp):
         func = _apply_optional_type
-    elif callable(type):
-        func = type
+    elif callable(tp):
+        func = tp
     else:
         raise ValueError(
-            'Cannot find a function to apply type "{}"'.format(type)
+            'Cannot find a function to apply type "{}"'.format(tp)
         )
 
-    args = getattr(type, "__args__", None)
+    args = getattr(tp, "__args__", None)
 
     if args:
         # this can be a Generic type from the typing module, like
@@ -126,20 +139,20 @@ def _safe_eval(string):
             raise
 
 
-def _build_simple_value(string, type):
-    if not type or issubclass_(type, str):
+def _build_simple_value(string, tp):
+    if not tp or issubclass_(tp, str):
         return string
-    elif issubclass_(type, collections.Mapping):
+    elif is_mapping_type(tp):
         entries = (
             re.split(r"\s*[:=]\s*", entry, maxsplit=1)
             for entry in string.split(";")
         )
-        if is_dict_value_iterable(type):
+        if is_dict_value_iterable(tp):
             entries = ((k, re.split(r"\s*,\s*", v)) for k, v in entries)
         return {k.strip(): v for k, v in entries}
-    elif issubclass_(type, tuple):
+    elif is_tuple_type(tp):
         return tuple(item for item in string.split(","))
-    elif issubclass_(type, collections.Iterable):
+    elif is_iterable_type(tp):
         return [item for item in string.split(",")]
     else:
         return string

--- a/nubia/internal/typing/inspect.py
+++ b/nubia/internal/typing/inspect.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+import collections.abc
+import sys
+from typing import Iterable, Mapping, TypeVar
+
+from nubia.internal.helpers import issubclass_
+
+PEP_560: bool = sys.version_info[:3] >= (3, 7, 0)
+
+if PEP_560:
+    from typing import Tuple, Union, _GenericAlias
+else:
+    from typing import TupleMeta, _Union
+
+
+def is_none_type(tp) -> bool:
+    """Checks whether a type is a `None' type."""
+    return tp is type(None)  # noqa E721
+
+
+def is_union_type(tp) -> bool:
+    """Checks whether a type is a union type."""
+    if PEP_560:
+        return (
+            tp is Union
+            or isinstance(tp, _GenericAlias)
+            and tp.__origin__ is Union
+        )
+    return type(tp) is _Union
+
+
+def is_optional_type(tp) -> bool:
+    """Checks whether a type is an optional type."""
+    return (
+        is_union_type(tp)
+        and len(tp.__args__) == 2
+        and any(map(is_none_type, tp.__args__))
+    )
+
+
+def is_mapping_type(tp) -> bool:
+    """Checks whether a type is a mapping type."""
+    if PEP_560:
+        return (
+            tp is Mapping
+            or isinstance(tp, _GenericAlias)
+            and issubclass_(tp.__origin__, collections.abc.Mapping)
+        )
+    return issubclass_(tp, collections.abc.Mapping)
+
+
+def is_tuple_type(tp) -> bool:
+    """Checks whether a type is a tuple type."""
+    if PEP_560:
+        return (
+            tp is Tuple
+            or isinstance(tp, _GenericAlias)
+            and tp.__origin__ is tuple
+        )
+    return type(tp) is TupleMeta
+
+
+def is_iterable_type(tp) -> bool:
+    """Checks whether a type is an iterable type."""
+    if PEP_560:
+        return (
+            tp is Iterable
+            or isinstance(tp, _GenericAlias)
+            and issubclass_(tp.__origin__, collections.abc.Iterable)
+        )
+    return issubclass_(tp, list)
+
+
+def is_typevar(tp) -> bool:
+    """Checks whether a type is a `TypeVar'."""
+    return type(tp) is TypeVar
+
+
+def get_first_type_argument(tp):
+    """Returns first type argument, e.g. `int' for `List[int]'."""
+    assert hasattr(tp, "__args__") and len(tp.__args__) > 0
+    return tp.__args__[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dataclasses;python_version<"3.7"
+dataclasses;python_version<'3.7'
 prettytable
 prompt-toolkit>=2
 Pygments

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dataclasses
+dataclasses;python_version<"3.7"
 prettytable
 prompt-toolkit>=2
 Pygments

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["sample", "docs", "tests"]),
     python_requires=">=3.6",
     setup_requires=["nose>=1.0", "coverage"],
-    tests_require=["nose>=1.0"],
+    tests_require=["nose>=1.0", "dataclasses;python_version<'3.7'"],
     install_requires=reqs,
     classifiers=(
         "Development Status :: 4 - Beta",

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -10,12 +10,8 @@
 import unittest
 from typing import Dict, List, Optional, Union
 
-from nubia.internal.helpers import (
-    catchall,
-    function_to_str,
-    is_optional,
-    is_union,
-)
+from nubia.internal.helpers import catchall, function_to_str
+from nubia.internal.typing.inspect import is_optional_type
 
 
 class HelpersTest(unittest.TestCase):
@@ -48,14 +44,9 @@ class HelpersTest(unittest.TestCase):
         self.assertRaises(KeyboardInterrupt, catchall, raise_keyboard_interrupt)
         self.assertRaises(SystemExit, catchall, raise_sysexit)
 
-    def test_is_union(self):
-        self.assertTrue(is_union(Union[str, int]))
-        self.assertFalse(is_union(List[str]))
-        self.assertFalse(is_union(Dict[str, int]))
-
     def test_is_optional(self):
-        self.assertFalse(is_optional(List[str]))
-        self.assertFalse(is_optional(Dict[str, int]))
-        self.assertFalse(is_optional(Union[str, int]))
-        self.assertTrue(is_optional(Optional[str]))
-        self.assertTrue(is_optional(Union[str, None]))
+        self.assertFalse(is_optional_type(List[str]))
+        self.assertFalse(is_optional_type(Dict[str, int]))
+        self.assertFalse(is_optional_type(Union[str, int]))
+        self.assertTrue(is_optional_type(Optional[str]))
+        self.assertTrue(is_optional_type(Union[str, None]))


### PR DESCRIPTION
This PR makes Nubia compatible with Python 3.7+ by taking into account the changes introduced by [PEP 560.](https://www.python.org/dev/peps/pep-0560/) The implementation was heavily inspired by [ilevkivskyi/typing_inspect](https://github.com/ilevkivskyi/typing_inspect) project.

Also run TravisCI tests against Python 3.7. 

Closes #2.