### PR TITLE
Adds _nubia_complete script as a deployable script

### DIFF
--- a/nubia_complete/main.py
+++ b/nubia_complete/main.py
@@ -16,14 +16,16 @@ from nubia_complete.shell import generate_shell_setup
 logger = logging.getLogger(__name__)
 
 
-def main(args):
+def main():
+    sys.exit(run(sys.argv))
+
+
+def run(args):
     opts_parser = argparse.ArgumentParser(
         description="A shell completion utility for nubia programs"
     )
 
-    subparsers = opts_parser.add_subparsers(
-        help="sub-command help", dest="mode"
-    )
+    subparsers = opts_parser.add_subparsers(help="sub-command help", dest="mode")
     opts_parser.add_argument(
         "--loglevel",
         type=str,
@@ -36,15 +38,12 @@ def main(args):
         "generate-shell-setup",
         help="Generates a bash/zsh " "setup script that you can source",
     )
-    complete_parser = subparsers.add_parser(
-        "complete", help="Triggers " "completions"
-    )
+    complete_parser = subparsers.add_parser("complete", help="Triggers " "completions")
     generate_parser.add_argument(
         "--target-binary-name",
         type=str,
         required=True,
-        help="The name of the nubia program we want "
-        "to generate a completer for",
+        help="The name of the nubia program we want " "to generate a completer for",
     )
     generate_parser.add_argument(
         "--command-model-path",
@@ -63,9 +62,7 @@ def main(args):
     log_level = logging.getLevelName(args.loglevel)
     logging.basicConfig(level=log_level)
     if args.mode == "generate-shell-setup":
-        return generate_shell_setup(
-            args.target_binary_name, args.command_model_path
-        )
+        return generate_shell_setup(args.target_binary_name, args.command_model_path)
     elif args.mode == "complete":
         return run_complete(args)
     else:
@@ -74,4 +71,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    run()

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setuptools.setup(
     python_requires=">=3.6",
     setup_requires=["nose>=1.0", "coverage"],
     tests_require=["nose>=1.0"],
+    entry_points={"console_scripts": ["_nubia_complete = nubia_complete.main:main"]},
     install_requires=reqs,
     classifiers=(
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This configures setup.py to install `_nubia_complete` as a script on target systems. This is part of making _nubia_complete easier to use for use cases outside of Facebook.
Next steps:
- Allow `_nubia_complete` to take the command model output in generate mode to generate a fully encapsulated shell script that doesn't require the model path to live in its own file.
- Documentation on how to configure and use _nubia_complete