### PR TITLE
Fix crashes when a subcommand has no docstring

### DIFF
--- a/nubia/internal/cmdbase.py
+++ b/nubia/internal/cmdbase.py
@@ -169,7 +169,7 @@ class AutoCommand(Command):
                 _sub_name = inspection.command.name
                 self._commands_completer.words.append(_sub_name)
                 self._commands_completer.meta_dict[_sub_name] = dedent(
-                    inspection.command.help
+                    inspection.command.help or ""
                 ).strip()
                 self._subcommand_names.append(_sub_name)
 

--- a/nubia/internal/cmdbase.py
+++ b/nubia/internal/cmdbase.py
@@ -169,7 +169,7 @@ class AutoCommand(Command):
                 _sub_name = inspection.command.name
                 self._commands_completer.words.append(_sub_name)
                 self._commands_completer.meta_dict[_sub_name] = dedent(
-                    inspection.command.help or ""
+                    inspection.command.help
                 ).strip()
                 self._subcommand_names.append(_sub_name)
 

--- a/nubia/internal/typing/__init__.py
+++ b/nubia/internal/typing/__init__.py
@@ -334,14 +334,11 @@ def inspect_object(obj, accept_bound_methods=False):
             metadata = inspect_object(candidate, accept_bound_methods=True)
             # ignore subcommands without docstring
             if not metadata.command.help:
-                cprint(
-                    (
-                        "[WARNING] The sub-command %s will not be loaded. " %
-                        metadata.command.name,
+                cprint((f"[WARNING] The sub-command {metadata.command.name} "
+                        "will not be loaded. "
                         "Please provide a help message by either defining a "
                         "docstring or filling the help argument in the "
-                        "@command annotation"
-                    ), "red")
+                        "@command annotation"), "red")
                 continue
             if metadata.command:
                 result["subcommands"].append((attr, metadata))

--- a/nubia/internal/typing/__init__.py
+++ b/nubia/internal/typing/__init__.py
@@ -65,6 +65,8 @@ from collections.abc import Container
 from functools import partial
 from inspect import ismethod, isclass
 
+from termcolor import cprint
+
 from nubia.internal.helpers import (
     get_arg_spec,
     function_to_str,
@@ -330,6 +332,16 @@ def inspect_object(obj, accept_bound_methods=False):
             if not callable(candidate):  # avoid e.g. properties
                 continue
             metadata = inspect_object(candidate, accept_bound_methods=True)
+            # ignore subcommands without docstring
+            if not metadata.command.help:
+                cprint(
+                    (
+                        "[WARNING] The sub-command {} will not be loaded. "
+                        "Please provide a help message by either defining a "
+                        "docstring or filling the help argument in the "
+                        "@command annotation"
+                    ).format(metadata.command.name), "red")
+                continue
             if metadata.command:
                 result["subcommands"].append((attr, metadata))
 

--- a/nubia/internal/typing/__init__.py
+++ b/nubia/internal/typing/__init__.py
@@ -336,11 +336,12 @@ def inspect_object(obj, accept_bound_methods=False):
             if not metadata.command.help:
                 cprint(
                     (
-                        "[WARNING] The sub-command {} will not be loaded. "
+                        "[WARNING] The sub-command %s will not be loaded. " %
+                        metadata.command.name,
                         "Please provide a help message by either defining a "
                         "docstring or filling the help argument in the "
                         "@command annotation"
-                    ).format(metadata.command.name), "red")
+                    ), "red")
                 continue
             if metadata.command:
                 result["subcommands"].append((attr, metadata))

--- a/tests/inspection_test.py
+++ b/tests/inspection_test.py
@@ -55,3 +55,15 @@ class InspectionTest(unittest.TestCase):
         self.assertEquals(2, len(subargs))
         self.assertTrue("arg1" in subargs.keys())
         self.assertTrue("argument-2" in subargs.keys())
+
+    def test_inspect_no_docstring(self):
+        @command
+        class SuperCommand:
+            """SuperHelp"""
+
+            @command
+            def my_function(self, arg1: str):
+                pass
+
+        data = inspect_object(SuperCommand)
+        self.assertEquals(0, len(data.subcommands))

--- a/tests/inspection_test.py
+++ b/tests/inspection_test.py
@@ -66,4 +66,4 @@ class InspectionTest(unittest.TestCase):
                 pass
 
         data = inspect_object(SuperCommand)
-        self.assertEquals(0, len(data.subcommands))
+        self.assertListEqual([], data.subcommands)

--- a/tests/supercommands_test.py
+++ b/tests/supercommands_test.py
@@ -88,7 +88,7 @@ class SuperCommandSpecTest(unittest.TestCase):
 
             @command
             def sub_command(self, arg1: str):
-                return "Hi %s" % arg1
+                return f"Hi {arg1}"
 
         shell = TestShell(commands=[SuperCommand])
 

--- a/tests/supercommands_test.py
+++ b/tests/supercommands_test.py
@@ -88,7 +88,7 @@ class SuperCommandSpecTest(unittest.TestCase):
 
             @command
             def sub_command(self, arg1: str):
-                return "Hi {}".format(arg1)
+                return "Hi %s" % arg1
 
         shell = TestShell(commands=[SuperCommand])
 

--- a/tests/supercommands_test.py
+++ b/tests/supercommands_test.py
@@ -80,3 +80,20 @@ class SuperCommandSpecTest(unittest.TestCase):
                 "--arg1=giza --arg2=22 --shared=15"
             ),
         )
+
+    def test_super_no_docstring(self):
+        @command
+        class SuperCommand:
+            "SuperHelp"
+
+            @command
+            def sub_command(self, arg1: str):
+                return "Hi {}".format(arg1)
+
+        shell = TestShell(commands=[SuperCommand])
+
+        with self.assertRaises(SystemExit):
+            shell.run_cli_line(
+                "test_shell super-command "
+                "sub-command --arg1=human"
+            )


### PR DESCRIPTION
If a subcommand no has a docstring, set an empty string by default.

This closes #44 