### PR TITLE
Fix to #43:  Subcommand aliases are broken.

### DIFF
--- a/example/commands/sample_commands.py
+++ b/example/commands/sample_commands.py
@@ -94,7 +94,7 @@ class SuperCommand:
         """
         cprint("My name is: {}".format(firstname))
 
-    @command
+    @command(aliases=["do"])
     def do_stuff(self, stuff: int):
         """
         doing stuff

--- a/nubia/internal/cmdbase.py
+++ b/nubia/internal/cmdbase.py
@@ -407,12 +407,8 @@ class AutoCommand(Command):
         assert self.super_command
         subcommands = self.metadata.subcommands
         for attr, inspection in subcommands:
-            if inspection.command.name == name:
+            if inspection.command.name == name or name in inspection.command.aliases:
                 return attr
-            else:
-                for alias in inspection.command.aliases:
-                    if alias == name:
-                       return attr
         # be explicit about returning None for readability
         return None
 

--- a/nubia/internal/cmdbase.py
+++ b/nubia/internal/cmdbase.py
@@ -409,6 +409,10 @@ class AutoCommand(Command):
         for attr, inspection in subcommands:
             if inspection.command.name == name:
                 return attr
+            else:
+                for alias in inspection.command.aliases:
+                    if alias == name:
+                       return attr
         # be explicit about returning None for readability
         return None
 

--- a/nubia/internal/typing/argparse.py
+++ b/nubia/internal/typing/argparse.py
@@ -99,7 +99,9 @@ def register_command(argparse_parser, inspection):
     # auto wrap the function with @command in case its not wrapped into one
     subparsers = _resolve_subparsers(argparse_parser)
 
-    subparser = subparsers.add_parser(_command.name, aliases=_command.aliases, help=_command.help)
+    subparser = subparsers.add_parser(
+        _command.name, aliases=_command.aliases, help=_command.help
+    )
 
     # Exclusive arguments needs to be added to argparse's mutually exclusive
     # groups

--- a/nubia/internal/typing/argparse.py
+++ b/nubia/internal/typing/argparse.py
@@ -99,7 +99,7 @@ def register_command(argparse_parser, inspection):
     # auto wrap the function with @command in case its not wrapped into one
     subparsers = _resolve_subparsers(argparse_parser)
 
-    subparser = subparsers.add_parser(_command.name, help=_command.help)
+    subparser = subparsers.add_parser(_command.name, aliases=_command.aliases, help=_command.help)
 
     # Exclusive arguments needs to be added to argparse's mutually exclusive
     # groups


### PR DESCRIPTION
sample_commands.py:**97** Added aliases='do' to do-stuff.
argparse.py:**102** Additional aliases argument to allow reference to the same subparser with different strings.
cmdbase.py:**412** Added this code to support alias or aliases for subcommand of the super-command.