### PR TITLE
fix tests and bump version 0.2b1

### DIFF
--- a/nubia/__init__.py
+++ b/nubia/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "statusbar",
 ]
 
-__version__ = "0.1b6"
+__version__ = "0.2b1"


### PR DESCRIPTION
- A small fix was needed to address the failing tests
- A version bump, 0.2 to mark that we are now on prompt_tookit 2+