### PR TITLE
Make checking for help handle command templates

### DIFF
--- a/nubia/internal/typing/__init__.py
+++ b/nubia/internal/typing/__init__.py
@@ -333,14 +333,16 @@ def inspect_object(obj, accept_bound_methods=False):
                 continue
             metadata = inspect_object(candidate, accept_bound_methods=True)
             # ignore subcommands without docstring
-            if not metadata.command.help:
-                cprint((f"[WARNING] The sub-command {metadata.command.name} "
-                        "will not be loaded. "
-                        "Please provide a help message by either defining a "
-                        "docstring or filling the help argument in the "
-                        "@command annotation"), "red")
-                continue
             if metadata.command:
+                if not metadata.command.help:
+                    cprint(
+                        (f"[WARNING] The sub-command {metadata.command.name} "
+                         "will not be loaded. "
+                         "Please provide a help message by either defining a "
+                         "docstring or filling the help argument in the "
+                         "@command annotation"), "red")
+                    continue
+
                 result["subcommands"].append((attr, metadata))
 
     return FunctionInspection(**result)


### PR DESCRIPTION
    When you define a supercommand template with a bunch of virtual functions
    that are implemented by specific commands that inherit the template, not
    all functions are instantiated by the template. This causes the checking
    for help in a subcommand to fail since command itself is not defined for
    these subcommand templates. If you add the command decorator to the template,
    then that is the function that gets invoked, not the one defined by the
    real command inherting the template.

    To avoid this, check if metadata.command is defined before checking for
    help.