### PR TITLE
Fix #62: Allow arguments with '-' in their name

### DIFF
--- a/nubia/internal/cmdbase.py
+++ b/nubia/internal/cmdbase.py
@@ -190,7 +190,7 @@ class AutoCommand(Command):
             for k, v in get_arguments_for_inspection(self.metadata, key_values).items()
             if v is not None
         }
-        remaining = {k: v for k, v in key_values.items() if k not in kwargs.keys()}
+        remaining = {k: v for k, v in key_values.items() if k.replace('-', '_') not in kwargs.keys()}
         return self._fn(**kwargs), remaining
 
     def run_interactive(self, cmd, args, raw):


### PR DESCRIPTION
Nubia expects you to use '_' in argument names to match up with the
characters python variable names allow. Nubia automatically converts
'_' to '-' in argument name when showing the possible arguments. Thus,
'start_time' is shown as 'start-time'. However, when attempting to
match up the supplied arguments with what's supported, it fails to
convert the '-' to '_' and so the match against supported arguments
fails.

This fix ensures that the check against expected arguments is made by
first converting the '-' in supplied arguments to '_'.