### PR TITLE
Fix erroneous call to parse_and_evaluate() in Nubia start_interactive() method

### DIFF
--- a/nubia/internal/nubia.py
+++ b/nubia/internal/nubia.py
@@ -216,7 +216,7 @@ class Nubia:
             for command in commands:
                 # execute
                 print("> {}".format(command))
-                ret = io_loop.parse_and_evaluate(sys.stdout, command)
+                ret = io_loop.parse_and_evaluate(command)
                 # We fail execution on the first failing command
                 if ret:
                     return ret

--- a/tests/read_stdin_test.py
+++ b/tests/read_stdin_test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+import os
+import sys
+import tempfile
+import unittest
+from nubia import argument, command
+from tests.util import TestShell
+
+class ReadStdinTest(unittest.TestCase):
+    def test_read_from_stdin(self):
+        @command
+        @argument("arg")
+        def test_command(arg: str) -> int:
+            """
+            Sample Docstring
+            """
+            self.assertEqual("test_arg", arg)
+            return 22
+
+        command_file = tempfile.NamedTemporaryFile(
+            mode="w+",
+            prefix="test_read_from_stdin",
+            delete=True
+        )
+        command_file.write("test-command arg=test_arg")
+        command_file.flush()
+        os.lseek(command_file.fileno(), 0, os.SEEK_SET)
+        os.dup2(command_file.fileno(), sys.stdin.fileno())
+        shell = TestShell(commands=[test_command])
+        self.assertEqual(22, shell.run(cli_args=["", "connect"]))


### PR DESCRIPTION
Fix #61:  Wrong args in io_loop.parse_and_evaluate() in start_interactive()

Summary:
In method start_interactive() Nubia reads all commands from sys.stdin if it is not a TTY. Afterwards it calls io_loop.parse_and_evaluate() for each command. This call had an extract argument "sys.stdout", causing runtime failure and exception.

The impact is that Nubia will fail to load commands from an input file, redirected by "<" on a shell command line.

The fix removes the extra argument.

