### PR TITLE
Update README.md to explain how to set Unix return codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ If you start a nubia-based program without a command, it automatically starts an
 The CLI mode works exactly like any traditional unix-based command line utility.
 ![Non-interactive Demo](docs/non_interactive.png?raw=true "Non-interactive demo")
 
+Have your `@command` decorated function return an `int` to send that value as the Unix return code for your non interactive CLI.
+
 ## Examples
 It starts with a function like this:
 ```py
@@ -47,18 +49,22 @@ from nubia import argument, command, context
 @command
 @argument("hosts", description="Hostnames to resolve", aliases=["i"])
 @argument("bad_name", name="nice", description="testing")
-def lookup(hosts: typing.List[str], bad_name: int):
+def lookup(hosts: typing.List[str], bad_name: int) -> int:
     """
     This will lookup the hostnames and print the corresponding IP addresses
     """
     ctx = context.get_context()
+
+    if not hosts:
+        cprint("No hosts supplied via --hosts")
+        return 1
+
     print(f"hosts: {hosts}")
     cprint(f"Verbose? {ctx.verbose}")
 
     for host in hosts:
         cprint(f"{host} is {socket.gethostbyname(host)}")
 
-    # optional, by default it's 0
     return 0
 ```
 


### PR DESCRIPTION
- Add line to explain if you return an int it's used as the return / exit code
- Edit example to type annotate `int` return value
- Add a check of a param in the example to return error to the CLI if found
- Encourage explicit rather than implict function style always returning 0 - *Zen of Python* inspired.

Today when using nubia for the first time this took me longer to workout. So I'd like to help future new users to understand how to achieve this Unix basic requirement so we get more compliant return coded CLIs.