### PR TITLE
docs: fix simple typo, sdout -> stdout

### DIFF
--- a/nubia/internal/nubia.py
+++ b/nubia/internal/nubia.py
@@ -274,7 +274,7 @@ class Nubia:
     def _pre_run(self, cli_args):
         args = self._parse_args(cli_args)
         self._setup_logging(args)
-        # check if we can add colors to sdout
+        # check if we can add colors to stdout
         self._setup_terminal(args)
 
         self._validate_args(args)


### PR DESCRIPTION
There is a small typo in nubia/internal/nubia.py.

Should read `stdout` rather than `sdout`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md